### PR TITLE
CSS for tables, copied from github theme of Typora.

### DIFF
--- a/theme/voidy-bootstrap/static/css/voidybootstrap-custom.css
+++ b/theme/voidy-bootstrap/static/css/voidybootstrap-custom.css
@@ -364,3 +364,38 @@ div.input_area {
 	font-weight: bold;
   margin-left: 10px;
 }
+
+/* Tables : copied from github theme of Typora. */
+table {
+  padding: 0;
+  word-break: initial;
+}
+table tr {
+  border-top: 1px solid #dfe2e5;
+  margin: 0;
+  padding: 0;
+}
+table tr:nth-child(2n),
+thead {
+  background-color: #f8f8f8;
+}
+table tr th {
+  font-weight: bold;
+  border: 1px solid #dfe2e5;
+  border-bottom: 0;
+  margin: 0;
+  padding: 6px 13px;
+}
+table tr td {
+  border: 1px solid #dfe2e5;
+  margin: 0;
+  padding: 6px 13px;
+}
+table tr th:first-child,
+table tr td:first-child {
+  margin-top: 0;
+}
+table tr th:last-child,
+table tr td:last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
CSS for tables. Without it some articles are not somewhat beautiful.