### PR TITLE
Article URL change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ INPUTDIR=$(BASEDIR)/content
 OUTPUTDIR=$(BASEDIR)/output
 CONFFILE=$(BASEDIR)/pelicanconf.py
 PUBLISHCONF=$(BASEDIR)/publishconf.py
+POSTPROCESS=$(BASEDIR)/content/postprocess.sh
 
 GITHUB_PAGES_BRANCH=master
 
@@ -41,7 +42,8 @@ help:
 	@echo '                                                                          '
 
 html:
-	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
+	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) &&\
+	[ -e $(POSTPROCESS) ] && sh $(POSTPROCESS)
 
 clean:
 	[ ! -d $(OUTPUTDIR) ] || rm -rf $(OUTPUTDIR)/*
@@ -72,7 +74,8 @@ else
 endif
 
 publish:
-	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(PUBLISHCONF) $(PELICANOPTS)
+	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(PUBLISHCONF) $(PELICANOPTS) &&\
+	[ -e $(POSTPROCESS) ] && sh $(POSTPROCESS)
 
 github: publish
 	ghp-import -m "Generate Pelican site" -b $(GITHUB_PAGES_BRANCH) $(OUTPUTDIR)

--- a/content/postprocess.sh
+++ b/content/postprocess.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cd output/articles/
+ln -s ../blog/* ./
+cd ../../

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -31,10 +31,8 @@ this_year = datetime.date.today().year
 
 # ARTICLE_PATHS = ['articles']
 ARTICLE_PATHS = [ 'articles/%dsy/' % y for y in range(start_year, this_year+2) ]
-ARTICLE_SAVE_AS = 'articles/{date:%Y}/{date:%m}/{slug}.html'
-ARTICLE_URL = 'articles/{date:%Y}/{date:%m}/{slug}.html'
-PAGE_SAVE_AS = '{slug}.html'
-PAGE_URL = '{slug}.html'
+ARTICLE_SAVE_AS = ARTICLE_URL ='{category}/{date:%Y}/{date:%m}/{slug}.html'
+PAGE_SAVE_AS = PAGE_URL ='{slug}.html'
 
 INDEX_SAVE_AS = 'articles.html'
 


### PR DESCRIPTION
Currently the URLs of articles are like
oumpy.github.io/articles/yyyy/mm/name.html,
regardless it is News or Blog.

This patch changes it like
oumpy.github.io/blog/yyyy/mm/name.html,
and for blog articles, make symbolic links and the same article can also be accessed via
oumpy.github.io/articles/yyyy/mm/name.html,
so that the already-announced links on Twitter would not be killed.