### PR TITLE
load plugin liquid_tags.youtube

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -59,7 +59,7 @@ PAGINATION_PATTERNS = (
 MARKUP = ('md', 'ipynb')
 
 PLUGIN_PATHS = ['./plugins']
-PLUGINS = ['pelican-ipynb.markup', 'render_math']
+PLUGINS = ['pelican-ipynb.markup', 'render_math', 'liquid_tags.youtube']
 
 # if you create jupyter files in the content dir, snapshots are saved with the same
 # metadata. These need to be ignored.


### PR DESCRIPTION
This patch enables inclusion of YouTube videos in pages & articles, by writing
{% youtube youtube_id [width] [height] %}
in markdown sources.
[width] & [height] can be omitted.