### PR TITLE
Show modified dates on selected pages

### DIFF
--- a/content/pages/achievements.md
+++ b/content/pages/achievements.md
@@ -1,6 +1,7 @@
 Title: 実績
 Date: 2020.03.13
 Modified: 2020.03.24
+Show_modified: True
 Tags: pages
 Slug: achievements
 Author:

--- a/content/pages/activities.md
+++ b/content/pages/activities.md
@@ -1,6 +1,7 @@
 Title: 活動内容
 Date: 2020.03.15
 Modified: 2020.03.22
+Show_modified: True
 Tags:
 Slug: activities
 Author: Python会

--- a/content/pages/recruit.md
+++ b/content/pages/recruit.md
@@ -1,6 +1,7 @@
 Title: 会員募集
 Date: 2020.03.13
 Modified: 2020.03.25
+Show_modified: True
 Tags: pages
 Slug: recruit
 Author: Python会

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -89,6 +89,7 @@ CUSTOM_FOOTER = "custom/footer.html"
 SKIP_COLOPHON = True
 
 CUSTOM_HTML_HEAD = "custom/html_head.html"
+CUSTOM_HEADER_PAGE = "custom/header_page.html"
 CUSTOM_HEADER_ARTICLE = "custom/header_article.html"
 CUSTOM_ARTICLE_HEADERS = ("article_header.html", "custom/open_in_colab_header.html",
                           "custom/toc_header.html", )
@@ -98,6 +99,7 @@ CUSTOM_ARTICLE_FOOTERS = ("taglist.html", "sharing.html", "custom/utterances.htm
                           "custom/open_in_colab_footer.html",
                           "custom/toc_footer.html",)
 
+CUSTOM_SCRIPTS_PAGE = "custom/page_showmodified_scripts.html"
 CUSTOM_SCRIPTS_ARTICLE = "sharing_scripts.html"
 # SIDEBAR_HIDE_CATEGORIES = True
 

--- a/theme/voidy-bootstrap/static/css/voidybootstrap-custom.css
+++ b/theme/voidy-bootstrap/static/css/voidybootstrap-custom.css
@@ -88,6 +88,11 @@ p.standfirst {
 	color: #999;
 }
 
+.modified-date, .page-header-info {
+  text-align: right;
+  color: #999;
+}
+
 .social-links {
 	font-size: 18px;
 }

--- a/theme/voidy-bootstrap/templates/includes/custom/header_page.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/header_page.html
@@ -1,0 +1,3 @@
+    <meta name="page:slug" property="og:page:slug" content="{{ page.slug }}">
+    <meta name="page:date" property="og:page:date" content="{{ page.date|strftime("%Y-%m-%d") }}">
+    <meta name="page:modified" property="og:page:modified" content="{{ page.modified|strftime("%Y-%m-%d") }}">

--- a/theme/voidy-bootstrap/templates/includes/custom/page_showmodified_scripts.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/page_showmodified_scripts.html
@@ -1,0 +1,12 @@
+{% if page.show_modified %}
+<script type="text/javascript">
+    (function() {
+        var modified = document.getElementsByName('page:modified')[0].content;
+        //document.querySelector('[itemprop="name headline"]').
+        $('header').after(
+//            '<p class="modified-date", style="text-align: right">( ' + modified + ' 最終更新 )</p>'
+            '<p class="modified-date">( ' + modified + ' 最終更新 )</p>'
+        );
+    })();
+</script>
+{% endif %}


### PR DESCRIPTION
By adding "Show_modified: True" to the metadata of a page, modified date for the page is shown at lower-right of the title.
recruit, activities, achievements are set for this.