### PR TITLE
Add video on recruit page.

### DIFF
--- a/content/pages/recruit.md
+++ b/content/pages/recruit.md
@@ -1,6 +1,6 @@
 Title: 会員募集
 Date: 2020.03.13
-Modified: 2020.04.03
+Modified: 2020.04.05
 Show_modified: True
 Slug: recruit
 Author: Python会
@@ -13,6 +13,9 @@ Pythonが全てわかる方も、なにもわからない方も、ちょっと�
 ## 新歓2020年度
 4月中は 本サイトと [YouTube](https://www.youtube.com/channel/UCh1eAeDCpsZeOh0Z9paNfHQ) によるオンライン新歓イベントを行う予定です。
 詳細は本サイトと [Twitter](https://twitter.com/oumed_python) にて、追ってお知らせします。
+
+### 紹介動画
+{% youtube 0u43x51nn-o %}
 
 ### 新歓チラシ
 新歓のチラシです。

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -57,7 +57,7 @@ PAGINATION_PATTERNS = (
 MARKUP = ('md', 'ipynb')
 
 PLUGIN_PATHS = ['./plugins']
-PLUGINS = ['pelican-ipynb.markup', 'render_math']
+PLUGINS = ['pelican-ipynb.markup', 'render_math', 'liquid_tags.youtube']
 
 # if you create jupyter files in the content dir, snapshots are saved with the same
 # metadata. These need to be ignored.


### PR DESCRIPTION
Introduction video added to recruit.md, by using liquid_tags plugin. It is better to process this pull request after #129 has been merged.