### PR TITLE
Auto-publish system replaced by GitHub Actions

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,3 +1,0 @@
-From: python:3.8-alpine
-
-RUN apk --update add git openssh make

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,0 +1,3 @@
+From: python:3.8-alpine
+
+RUN apk --update add git openssh make

--- a/.github/workflows/deploy_on_site.yml
+++ b/.github/workflows/deploy_on_site.yml
@@ -13,11 +13,16 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: python:3.8-alpine
+    runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.8' # Semantic version range syntax or exact version of a Python version
+        architecture: 'x64' # Optional - x64 or x86, defaults to x64
+
     - name: Checkout master
       uses: actions/checkout@v2
       with:
@@ -40,6 +45,7 @@ jobs:
 
     - name: Initialize Repository
       run: |
+        python -m pip install --upgrade pip
         pip install --user -r requirements.txt
         sh tools/init.sh
         git config --global user.name $GITHUB_ACTOR

--- a/.github/workflows/deploy_on_site.yml
+++ b/.github/workflows/deploy_on_site.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Deploy on Site
       run: |
-        make publish
+        make clean && make publish
         cd output/
         git add .
         git commit -m 'master branch updated.' && git push

--- a/.github/workflows/deploy_on_site.yml
+++ b/.github/workflows/deploy_on_site.yml
@@ -23,6 +23,24 @@ jobs:
         python-version: '3.8' # Semantic version range syntax or exact version of a Python version
         architecture: 'x64' # Optional - x64 or x86, defaults to x64
 
+    - name: pip update
+      run: |
+        python -m pip install --upgrade pip
+
+    - name: Checkout master branch
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Initialize Repository
+      run: |
+        pip install -r requirements.txt
+        sh tools/init.sh
+
+    - name: Make the Product
+      run: |
+        make clean && make publish
+
     - name: Install SSH Key
       uses: shimataro/ssh-key-action@v2
       with:
@@ -36,24 +54,11 @@ jobs:
             PreferredAuthentications publickey
             IdentityFile ~/.ssh/identity
 
-    - name: Checkout master
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - name: Initialize Repository
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        sh tools/init.sh
-        git config --global user.name $GITHUB_ACTOR
-        cd output/
-        git config --local --add url.github:.pushInsteadOf https://github.com/
-        git config --local --add url.github:.pushInsteadOf git@github.com:
-
     - name: Deploy on Site
       run: |
-        make clean && make publish
         cd output/
+        git config user.name $GITHUB_ACTOR
+        git config --add url.github:.pushInsteadOf https://github.com/
+        git config --add url.github:.pushInsteadOf git@github.com:
         git add .
         git commit -m 'master branch updated.' && git push

--- a/.github/workflows/deploy_on_site.yml
+++ b/.github/workflows/deploy_on_site.yml
@@ -1,0 +1,55 @@
+# This is a workflow to deploy master branch
+
+name: Deploy_on_site
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: python:3.8-alpine
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Checkout master
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Install SSH Key
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ secrets.bot_id_ecdsa }}
+        name: id_ecdsa
+        known_hosts: ${{ secrets.known_hosts }}
+        config: |
+          Host github github.com
+            HostName github.com
+            User ${{ secrets.bot_id_account }}
+            PreferredAuthentications publickey
+            IdentityFile ~/.ssh/id_ecdsa
+            UseKeychain yes
+            AddKeysToAgent yes
+
+    - name: Initialize Repository
+      run: |
+        pip install --user -r requirements.txt
+        sh tools/init.sh
+        git config --global user.name $GITHUB_ACTOR
+        cd output/
+        git config --local --add url.github:.pushInsteadOf https://github.com/
+        git config --local --add url.github:.pushInsteadOf git@github.com:
+
+    - name: Deploy on Site
+      run: |
+        make clean && make publish
+        cd output/
+        git add .
+        git commit -m 'master branch updated.' && git push

--- a/.github/workflows/deploy_on_site.yml
+++ b/.github/workflows/deploy_on_site.yml
@@ -23,11 +23,6 @@ jobs:
         python-version: '3.8' # Semantic version range syntax or exact version of a Python version
         architecture: 'x64' # Optional - x64 or x86, defaults to x64
 
-    - name: Checkout master
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-
     - name: Install SSH Key
       uses: shimataro/ssh-key-action@v2
       with:
@@ -40,6 +35,11 @@ jobs:
             User ${{ secrets.bot_id_account }}
             PreferredAuthentications publickey
             IdentityFile ~/.ssh/identity
+
+    - name: Checkout master
+      uses: actions/checkout@v2
+      with:
+        submodules: true
 
     - name: Initialize Repository
       run: |

--- a/.github/workflows/deploy_on_site.yml
+++ b/.github/workflows/deploy_on_site.yml
@@ -32,16 +32,14 @@ jobs:
       uses: shimataro/ssh-key-action@v2
       with:
         key: ${{ secrets.bot_id_ecdsa }}
-        name: id_ecdsa
+        name: identity
         known_hosts: ${{ secrets.known_hosts }}
         config: |
           Host github github.com
             HostName github.com
             User ${{ secrets.bot_id_account }}
             PreferredAuthentications publickey
-            IdentityFile ~/.ssh/id_ecdsa
-            UseKeychain yes
-            AddKeysToAgent yes
+            IdentityFile ~/.ssh/identity
 
     - name: Initialize Repository
       run: |

--- a/.github/workflows/deploy_on_site.yml
+++ b/.github/workflows/deploy_on_site.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install SSH Key
       uses: shimataro/ssh-key-action@v2
       with:
-        key: ${{ secrets.bot_id_ecdsa }}
+        key: ${{ secrets.bot_identity }}
         name: identity
         known_hosts: ${{ secrets.known_hosts }}
         config: |

--- a/.github/workflows/deploy_on_site.yml
+++ b/.github/workflows/deploy_on_site.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Initialize Repository
       run: |
         python -m pip install --upgrade pip
-        pip install --user -r requirements.txt
+        pip install -r requirements.txt
         sh tools/init.sh
         git config --global user.name $GITHUB_ACTOR
         cd output/

--- a/.github/workflows/deploy_on_site.yml
+++ b/.github/workflows/deploy_on_site.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Deploy on Site
       run: |
-        make clean && make publish
+        make publish
         cd output/
         git add .
         git commit -m 'master branch updated.' && git push


### PR DESCRIPTION
This is a childish implementation of #149. Instead of the present external server, it runs compiling & publishing on a Docker container provided by GitHub Actions. It closes everything within GitHub.

I DON'T KNOW whether it works, largely because I'm very new to GitHub Actions. However I think it is harmless even if it doesn't work.
I temporally stopped the webhook trigger to the external server (set dummy.cgi, rather than the correct deploy.cgi). After some checks which you can, please try.