### PR TITLE
Do not make center images of open in github / colab 

### DIFF
--- a/theme/voidy-bootstrap/static/css/voidybootstrap-custom.css
+++ b/theme/voidy-bootstrap/static/css/voidybootstrap-custom.css
@@ -60,6 +60,11 @@ img{
 	margin: auto;
 }
 
+img.notebook-badge-image {
+	margin-right: 10px!important;
+  display: inline!important;
+}
+
 body{
 	font-size: 16px;
 }


### PR DESCRIPTION
I centered all images, but didn't want to do that for the images of open in GitHub / colab, so I added the css code.

Please check