### PR TITLE
Bugfix: add IPython in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pelican
 Markdown
 nbconvert
+IPython


### PR DESCRIPTION
nbconvert does not depend on IPython. pelican-ipynb plugin depends on both.