### PR TITLE
Correct SSH configuration in GitHub Actions Auto-publish System

### DIFF
--- a/.github/workflows/deploy_on_site.yml
+++ b/.github/workflows/deploy_on_site.yml
@@ -50,7 +50,7 @@ jobs:
         config: |
           Host github github.com
             HostName github.com
-            User ${{ secrets.bot_id_account }}
+            User git
             PreferredAuthentications publickey
             IdentityFile ~/.ssh/identity
 


### PR DESCRIPTION
Correct username for GitHub in SSH authentication. (It MUST be 'git'.)

I expect this patch will solve the problem #170 in #149 .