### PR TITLE
Auto-Summary System for articles

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -151,6 +151,8 @@ HTMLTAGS_IN_SUMMARY = ('a', 'font', 's', 'strong', 'em', 'u', 'b')
 def filter_makesummary(s, n):
     htmltag_regex = r'<[^>]*?>'
     s = re.compile(r'[\s　]+').sub(' ', s)
+    s = re.compile(r'<(style|STYLE)(|\s+\S+)>.*?</(style|STYLE)>').sub(' ', s) # for jupyter. in general, probably buggy.
+    s = re.compile(r'([\s　]|&#182;)+').sub(' ', s)
     cur_pos = 0
     length = 0
     max_length = SUMMARY_MAX_LENGTH

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 import datetime
 import os
+import re
 import sys
 sys.path.append(os.curdir)
 
@@ -132,6 +133,57 @@ DISPLAY_RECENT_POSTS_ON_SIDEBAR=True
 
 TWITTER_CARD = True
 OPEN_GRAPH = True
+
+SUMMARY_MAX_LENGTH = 140  # same as Twitter
+
+JINJA_FILTERS = ()
+def filter_removetag(s):
+    return re.compile(r'<[^>]*?>').sub('', s)
+JINJA_FILTERS += (('removetag', filter_removetag),)
+def filter_left(s, n):
+    if len(s) <= n:
+        return s
+    else:
+        return s[:n]
+JINJA_FILTERS += (('left', filter_left),)
+
+HTMLTAGS_IN_SUMMARY = ('a', 'font', 's', 'strong', 'em', 'u', 'b')
+def filter_makesummary(s, n):
+    htmltag_regex = r'<[^>]*?>'
+    s = re.compile(r'[\s　]+').sub(' ', s)
+    cur_pos = 0
+    length = 0
+    max_length = SUMMARY_MAX_LENGTH
+    tag_stack = []
+    ret = ''
+    for m in re.finditer(htmltag_regex, s):
+        start = m.start()
+        end = m.end()
+        tag = m.group()
+        if length + (start - cur_pos) < max_length:
+            tag_sp = re.match(r'(</|<)([^\s/>]*)', tag).group(2).lower()
+            if tag_sp in HTMLTAGS_IN_SUMMARY:
+                if tag[1] == '/':
+                    tag_stack.pop()
+                else:
+                    tag_stack.append(tag_sp)
+                ret += s[cur_pos: end]
+            else:
+                ret += s[cur_pos: start]
+            length += start - cur_pos
+            cur_pos = end
+        else:
+            w = max_length - length
+            ret += s[cur_pos: cur_pos + w]
+            for t in tag_stack[::-1]:
+                ret += '</' + t + '>'
+            break
+    else:
+        ret += s[cur_pos: cur_pos + (max_length - length)]
+    ret += '.....'
+    return ret
+JINJA_FILTERS += (('makesummary', filter_makesummary),)
+
 
 # Read user's custom settings.
 from content.contentconf import *

--- a/theme/voidy-bootstrap/templates/includes/custom/index_summary.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/index_summary.html
@@ -1,0 +1,9 @@
+      <div class="summary">
+        {% if article.standfirst %}
+          <p class="standfirst">{{ article.standfirst|e }}</p>
+        {% endif %}
+		{{ article.summary }}
+		<p class="content-emphasis"><a href="{{ SITEURL }}/{{ article.url }}">
+			Read more... <i class="fa fa-arrow-circle-right fa-fw fa-lg"></i> 
+		</a></p>
+      </div>

--- a/theme/voidy-bootstrap/templates/includes/custom/index_summary.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/index_summary.html
@@ -2,8 +2,12 @@
         {% if article.standfirst %}
           <p class="standfirst">{{ article.standfirst|e }}</p>
         {% endif %}
-		{{ article.summary }}
-		<p class="content-emphasis"><a href="{{ SITEURL }}/{{ article.url }}">
-			Read more... <i class="fa fa-arrow-circle-right fa-fw fa-lg"></i> 
-		</a></p>
+        {% if article.summary is defined and article.summary|length >= SUMMARY_MIN_LENGTH|default(1) %}
+          {{ article.summary }}
+        {% else %}
+          <p>{{ article.content|makesummary(SUMMARY_MAX_LENGTH) }}</p>
+          {% endif %}
+        <p class="content-emphasis"><a href="{{ SITEURL }}/{{ article.url }}">
+          Read more... <i class="fa fa-arrow-circle-right fa-fw fa-lg"></i> 
+        </a></p>
       </div>

--- a/theme/voidy-bootstrap/templates/includes/index_summaries.html
+++ b/theme/voidy-bootstrap/templates/includes/index_summaries.html
@@ -1,0 +1,14 @@
+{% if articles %}
+  {% for article in (articles_page.object_list if articles_page else articles) %}
+    <article>
+      {% for file in CUSTOM_INDEX_ARTICLE_HEADERS %}
+        {% include "includes/" + file %}
+      {% else %}
+        {% include "includes/article_header.html" %}
+      {% endfor %}
+
+      {% include "includes/index_summary.html" %}
+    </article>
+    <hr />
+  {% endfor %}
+{% endif %}

--- a/theme/voidy-bootstrap/templates/includes/index_summaries.html
+++ b/theme/voidy-bootstrap/templates/includes/index_summaries.html
@@ -7,7 +7,7 @@
         {% include "includes/article_header.html" %}
       {% endfor %}
 
-      {% include "includes/index_summary.html" %}
+      {% include "includes/custom/index_summary.html" %}
     </article>
     <hr />
   {% endfor %}


### PR DESCRIPTION
This is the first implementation for issue #155 .
For articles without summary, this system generates the summary automatically, by taking twitter-long part of the beginning of the article, keeping some selected html tags (a, font, etc) & deleting others.

You can see from the preview that it fairly improves the view of the blog page, and I think it motivates the readers to read the articles.

Unfortunately for jupiter notebooks it outputs nonsense headers, but I don't think it is not a critical problem, and fixable later if necessary.