### PR TITLE
Alternative Japanese name for categories

### DIFF
--- a/content/contentconf.py
+++ b/content/contentconf.py
@@ -48,14 +48,16 @@ CUSTOM_RELATED_ARTICLES_TITLE = "関連記事"
 OPEN_GRAPH_IMAGE = 'logo.jpg'
 
 DISPLAY_PAGES_ON_MENU = False
-blog_title = '技術ブログ'
-news_title = 'Python会からのお知らせ'
+CUSTOM_CATEGORY_NAMES = {
+    'News': 'お知らせ',
+    'Blog': '技術ブログ',
+}
 ADD_ON_MENU = (
     ('Python会について', 'index.html'),
     ('活動内容', 'activities.html'),
     ('実績', 'achievements.html'),
-    (blog_title, 'blog.html'),
-    ('お知らせ', 'news.html'),
+    (CUSTOM_CATEGORY_NAMES['Blog'], 'blog.html'),
+    (CUSTOM_CATEGORY_NAMES['News'], 'news.html'),
     ('会員募集', 'recruit.html'),
     ('Contact', 'contact.html'),
 )
@@ -63,7 +65,7 @@ HIDE_ARCHIVES_ON_MENU = True
 SIDEBAR_HIDE_CATEGORIES = True
 
 SHOW_CATEGORY_TITLE = True
-CUSTOM_CATEGORY_TITLES = {'Blog': blog_title, 'News': news_title}
+CUSTOM_CATEGORY_TITLES = {'News': 'Python会からのお知らせ'}
 def readfile(filename):
     with open(filename, 'r') as f:
         content = f.readlines()

--- a/content/contentconf.py
+++ b/content/contentconf.py
@@ -64,6 +64,7 @@ ADD_ON_MENU = (
 HIDE_ARCHIVES_ON_MENU = True
 SIDEBAR_HIDE_CATEGORIES = True
 
+SHOW_CATEGORIES_ON_LIST = False
 SHOW_CATEGORY_TITLE = True
 CUSTOM_CATEGORY_TITLES = {'News': 'Python会からのお知らせ'}
 def readfile(filename):

--- a/theme/voidy-bootstrap/templates/category.html
+++ b/theme/voidy-bootstrap/templates/category.html
@@ -1,0 +1,47 @@
+{% extends "index.html" %}
+{% block title %}Category:{{ category }} - {{ SITENAME }}{% endblock %}
+{% block metadesc %}{{ SITETAGALT }}Posts in category {{ category }}{% endblock %}
+
+{% block    custom_header %}
+{% if CUSTOM_HEADER_CATEGORY %}
+{% include "includes/" + CUSTOM_HEADER_CATEGORY %}
+{% endif %}
+{% endblock custom_header%}
+
+{% block    container_header %}
+{% if CUSTOM_CONTAINER_TOP_CATEGORY %}
+{% include "includes/" + CUSTOM_CONTAINER_TOP_CATEGORY %}
+{% endif %}
+{% endblock container_header %}
+
+{% block    content_header %}
+{% if CUSTOM_CONTENT_TOP_CATEGORY %}
+{% include "includes/" + CUSTOM_CONTENT_TOP_CATEGORY %}
+{% endif %}
+<ol class="breadcrumb">
+    <li><a href="{{ SITEURL }}/" title="Home" rel="home">
+		<i class="fa fa-home fa-fw fa-lg"></i> </a></li>
+{% if CATEGORIES_URL %}
+    <li><a href="{{ SITEURL }}/{{ CATEGORIES_URL }}">Categories </a></li>
+{% else %}
+    <li>Categories </li>
+{% endif %}
+    <li class="active">{{ category }}</li>
+</ol>
+{% endblock content_header %}
+
+{% block article %}
+{% include "includes/index_summaries.html" %}
+{% endblock article %}
+
+{% block    content_footer %}
+{% if CUSTOM_CONTENT_BOTTOM_CATEGORY %}
+{% include "includes/" + CUSTOM_CONTENT_BOTTOM_CATEGORY %}
+{% endif %}
+{% endblock content_footer %}
+
+{% block    container_footer %}
+{% if CUSTOM_CONTAINER_BOTTOM_CATEGORY %}
+{% include "includes/" + CUSTOM_CONTAINER_BOTTOM_CATEGORY %}
+{% endif %}
+{% endblock container_footer %}

--- a/theme/voidy-bootstrap/templates/category.html
+++ b/theme/voidy-bootstrap/templates/category.html
@@ -30,9 +30,9 @@
 {% endif %}
 {% set cat = category|string %}
 {% if CUSTOM_CATEGORY_NAMES is defined and cat in CUSTOM_CATEGORY_NAMES %}
-    <li class="active">{{ CUSTOM_CATEGORY_NAMES[cat] }}</li>
+    <li class="active"><a href="{{ SITEURL }}/{{ page_name }}.html">{{ CUSTOM_CATEGORY_NAMES[cat] }}</a></li>
 {% else %}
-    <li class="active">{{ category }}</li>
+    <li class="active"><a href="{{ SITEURL }}/{{ page_name }}.html">{{ category }}</a></li>
 {% endif %}
 </ol>
 {% endblock content_header %}

--- a/theme/voidy-bootstrap/templates/category.html
+++ b/theme/voidy-bootstrap/templates/category.html
@@ -20,11 +20,13 @@
 {% endif %}
 <ol class="breadcrumb">
     <li><a href="{{ SITEURL }}/" title="Home" rel="home">
-		<i class="fa fa-home fa-fw fa-lg"></i> </a></li>
+        <i class="fa fa-home fa-fw fa-lg"></i> </a></li>
+{% if SHOW_CATEGORIES_ON_LIST|default(true) %}
 {% if CATEGORIES_URL %}
     <li><a href="{{ SITEURL }}/{{ CATEGORIES_URL }}">Categories </a></li>
 {% else %}
     <li>Categories </li>
+{% endif %}
 {% endif %}
 {% set cat = category|string %}
 {% if CUSTOM_CATEGORY_NAMES is defined and cat in CUSTOM_CATEGORY_NAMES %}

--- a/theme/voidy-bootstrap/templates/category.html
+++ b/theme/voidy-bootstrap/templates/category.html
@@ -26,7 +26,12 @@
 {% else %}
     <li>Categories </li>
 {% endif %}
+{% set cat = category|string %}
+{% if CUSTOM_CATEGORY_NAMES is defined and cat in CUSTOM_CATEGORY_NAMES %}
+    <li class="active">{{ CUSTOM_CATEGORY_NAMES[cat] }}</li>
+{% else %}
     <li class="active">{{ category }}</li>
+{% endif %}
 </ol>
 {% endblock content_header %}
 

--- a/theme/voidy-bootstrap/templates/category.html
+++ b/theme/voidy-bootstrap/templates/category.html
@@ -34,6 +34,9 @@
 {% else %}
     <li class="active"><a href="{{ SITEURL }}/{{ page_name }}.html">{{ category }}</a></li>
 {% endif %}
+{% if articles_paginator is defined and articles_paginator._num_pages > 1 %}
+    <li class="text-muted">{{ articles_page.number }} / {{ articles_paginator._num_pages }} pages</li>
+{% endif %}
 </ol>
 {% endblock content_header %}
 

--- a/theme/voidy-bootstrap/templates/includes/custom/article_header_info.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/article_header_info.html
@@ -10,7 +10,13 @@
     {% endif %}
     in 
     <a href="{{ SITEURL }}/{{ article.category.url }}">
-      {{ article.category }}</a>
+    {% set cat = article.category|string %}
+    {% if CUSTOM_CATEGORY_NAMES is defined and cat in CUSTOM_CATEGORY_NAMES %}
+      {{ CUSTOM_CATEGORY_NAMES[cat] }}
+    {% else %}
+      {{ cat }}
+    {% endif %}
+    </a>
     &nbsp;&nbsp;
     {% if PDF_PROCESSOR %}
     <span class="label">

--- a/theme/voidy-bootstrap/templates/includes/custom/content_top_category.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/content_top_category.html
@@ -1,14 +1,14 @@
 {% set cat = category|string %}
 {% if SHOW_CATEGORY_TITLE %}
+<header>
   {% if CUSTOM_CATEGORY_TITLES is defined and cat in CUSTOM_CATEGORY_TITLES %}
-<header>
   <h1 itemprop="name headline">{{ CUSTOM_CATEGORY_TITLES[cat] }}</h1>
-</header>
+  {% elif CUSTOM_CATEGORY_NAMES is defined and cat in CUSTOM_CATEGORY_NAMES %}
+  <h1 itemprop="name headline">{{ CUSTOM_CATEGORY_NAMES[cat] }}</h1>
   {% else %}
-<header>
   <h1 itemprop="name headline">{{ cat }}</h1>
-</header>
   {% endif %}
+</header>
 {% endif %}
 {% if CATEGORY_CONTENTS is defined and cat in CATEGORY_CONTENTS and output_file == page_name+'.html' %}
 {{ CATEGORY_CONTENTS[cat] }}

--- a/theme/voidy-bootstrap/templates/includes/custom/sidebar.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/sidebar.html
@@ -23,7 +23,12 @@
 <div class="box-contents">
 	<ul class="list-unstyled category-links">
 {% for cat, null in categories %}
+  {% set cat = cat|string %}
+  {% if CUSTOM_CATEGORY_NAMES is defined and cat in CUSTOM_CATEGORY_NAMES %}
+  <li><a href="{{ SITEURL }}/{{ cat.url }}" >&#x2022; {{ CUSTOM_CATEGORY_NAMES[cat] }}</a></li>
+  {% else %}
   <li><a href="{{ SITEURL }}/{{ cat.url }}" >&#x2022; {{ cat }}</a></li>
+  {% endif %}
 {% endfor %}
 </ul>
 </div>


### PR DESCRIPTION
This patch enables a new option CUSTOM_CATEGORY_NAMES, which is set in contentconf.py as
{'Blog': '技術ブログ', 'News': 'お知らせ'}。Alternative names are shown instead of the internal category name, everywhere in the website.