### PR TITLE
Fix typo in neural_tangents.ipynb

### DIFF
--- a/content/articles/2020sy/Blog/neural_tangents.ipynb
+++ b/content/articles/2020sy/Blog/neural_tangents.ipynb
@@ -720,7 +720,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### NKTの場合"
+    "### NTKの場合"
    ]
   },
   {


### PR DESCRIPTION
I found a small typo. 
NKT -> NTK