### PR TITLE
Sitemap.xml added

### DIFF
--- a/content/contentpublishconf.py
+++ b/content/contentpublishconf.py
@@ -5,6 +5,21 @@ SITEREPOSITORY = 'https://github.com/oumpy/oumpy.github.io.git'
 # If your site is available via HTTPS, make sure SITEURL begins with https://
 SITEURL = 'oumpy.github.io'
 
+# configuration for sitemap plugin
+SITEMAP = {
+    'format': 'xml',
+    'priorities': {
+        'articles': 0.5,
+        'indexes': 0.5,
+        'pages': 0.5
+    },
+    'changefreqs': {
+        'articles': 'weekly',
+        'indexes': 'weekly',
+        'pages': 'weekly'
+    }
+}
+
 # Following items are often useful when publishing
 # Services
 # GOOGLE_ANALYTICS = 'UA-12345678-9'

--- a/publishconf.py
+++ b/publishconf.py
@@ -17,4 +17,9 @@ from pelicanconf import *
 
 # DELETE_OUTPUT_DIRECTORY = True
 
+# plugins which are applied only on publish
+PLUGINS += [
+    'sitemap',
+]
+
 from content.contentpublishconf import *


### PR DESCRIPTION
By using sitemap plugin, sitemap.xml is added to the site, for crawlers of google, etc. 

Note that this works only for `make publish`, so does nothing in the preview.