### PR TITLE
autosummary: small bugfix

### DIFF
--- a/myplugins/autosummary/autosummary.py
+++ b/myplugins/autosummary/autosummary.py
@@ -63,7 +63,7 @@ def make_autosummary(content, settings):
                             tag_stack.pop()
                             summary += '</%s>' % newtag
                         else:
-                            tag_stack.append(tag_sp)
+                            tag_stack.append(newtag)
                             summary += '<%s>' % newtag
                         break
                 else:


### PR DESCRIPTION
There was a small bug. When summary ends in `<h2>...</h2>` for example, it did not close the replaced `<strong>` correctly. It was something like typo, and it has now been corrected.