### PR TITLE
Move article dates, from above title to below title

### DIFF
--- a/theme/voidy-bootstrap/templates/includes/custom/article_header.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/article_header.html
@@ -1,3 +1,2 @@
-{% include "includes/article_header_date.html" %}
 {% include "includes/article_header_title.html" %}
 {% include "includes/custom/article_header_info.html" %}

--- a/theme/voidy-bootstrap/templates/includes/custom/article_header_info.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/article_header_info.html
@@ -1,7 +1,8 @@
 <div class="article-header-info">
   <p>
+    {% include "includes/article_header_date.html" %}
     {% if article.authors %}
-      Posted by 
+      - Posted by 
       {% for author in article.authors -%}
         <a href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>{% if not loop.last %}, {% endif %}
       {% endfor %}


### PR DESCRIPTION
It saves spaces & increases number of articles you can see on the list at the same time.