### PR TITLE
correct typo

### DIFF
--- a/content/contentconf.py
+++ b/content/contentconf.py
@@ -80,7 +80,7 @@ DEFAULT_PAGINATION = 10
 CUSTOM_TAG_BADGE_COLOR = 'blue'
 TAG_GROUPS = [ # (groupname, [articles,...,], badge_color )
     ('Research tools & techniques', ['Bioinformatics', 'Machine Learning', 'Statistics', 'Data Science Competition'], 'darkorange'),
-    ('Programming', ['Python', 'Shell script', 'GitHub', '競技プログラミング'], 'darkreen'),
+    ('Programming', ['Python', 'Shell script', 'GitHub', '競技プログラミング'], 'darkgreen'),
     ('その他', ['論文関連', '検定試験', '海外留学'], CUSTOM_TAG_BADGE_COLOR),
 ]
 CUSTOM_TAG_BADGE_COLORS = {'News' : 'hotpink'}


### PR DESCRIPTION
'darkreen' -> 'darkgreen'.
Thanks to the clever correction by shields.io, it did not affect the appearance of the site.