### PR TITLE
Move copyright information from theme to content/contentconf

### DIFF
--- a/content/contentconf.py
+++ b/content/contentconf.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*- #
 # site-specific settings
+import datetime
+
 GITHUB_ACCOUNT = 'oumpy'
 SOURCEREPOSITORY_NAME = 'hp_management'
 
@@ -13,6 +15,8 @@ AUTHOR_DESCRIPTION = u'Now is better than never'
 # AUTHOR_WEB = 'https://twitter.com/oumed_python'
 SITESUBTITLE ='Now is better than never.'
 SITETAG = SITENAME
+COPYRIGHT_YEAR = datetime.date.today().year
+COPYRIGHT_AUTHOR = SITENAME
 
 # Social
 SOCIAL = ( # (name, URL, icon, color, size)

--- a/theme/voidy-bootstrap/templates/includes/custom/footer.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/footer.html
@@ -3,7 +3,7 @@
 <address id="site-colophon" style="margin:0px;padding:5px">
     <div class="text-center">
     <p class="text-dark" style="margin:0px">
-        © 2020 大阪大学医学部 Python会
+        © {{ COPYRIGHT_YEAR|default(2020) }} {{ COPYRIGHT_AUTHOR|default(AUTHOR) }}
     </p>
     <p class="text-muted">
     Site built using <a href="http://getpelican.com/" target="_blank">Pelican</a>


### PR DESCRIPTION
Parameters COPYRIGHT_YEAR & COPYRIGHT_AUTHOR are set in contentconf.py
The appearance is totally unchanged.
You don't have to update the theme every year. The year is now set automatically by Python, at every update of master branch.