### PR TITLE
Delete 'A Page in' from the default description of pages

### DIFF
--- a/theme/voidy-bootstrap/templates/page.html
+++ b/theme/voidy-bootstrap/templates/page.html
@@ -1,0 +1,79 @@
+{% extends "base.html" %}
+{% block title %}{{ page.title }} - {{ SITENAME }}{% endblock %}
+{% block metadesc %}{% if page.description %}{{ page.description|e }}{% else %}A Page in {{ SITETAG }}: {{ page.title }}{% endif %}{% endblock %}
+{% block open_graph %}
+{% if OPEN_GRAPH %}
+    <meta property="og:type" content="article"/>
+    <meta property="og:title" content="{{ page.title|striptags|e }}"/>
+    <meta property="og:url" content="{{ SITEURL }}/{{ page.url }}"/>
+    {% if page.description %}
+      <meta property="og:description" content="{{ page.description|striptags|e }}"/>
+    {% endif %}
+    {% if page.social_image %}
+      <meta property="og:image"
+            content="{{ SITEURL }}/images/{{ page.social_image }}"/>
+    {% else %}
+      {% if DEFAULT_SOCIAL_IMAGE %}
+        <meta property="og:image"
+              content="{{ SITEURL }}/images/{{ DEFAULT_SOCIAL_IMAGE }}"/>
+      {% endif %}
+    {% endif %}
+{% endif %}
+{% endblock %}
+{% block custom_header %}
+{% if CUSTOM_HEADER_PAGE %}
+{% include "includes/" + CUSTOM_HEADER_PAGE %}
+{% endif %}
+{% endblock custom_header %}
+{% block container_header %}
+{% if CUSTOM_CONTAINER_TOP_PAGE %}
+{% include "includes/" + CUSTOM_CONTAINER_TOP_PAGE %}
+{% endif %}
+{% endblock container_header %}
+{% block content_header %}
+{% include "includes/" + CUSTOM_CONTENT_TOP_PAGE|default("page_top.html") ignore missing %}
+{% endblock content_header %}
+
+{% block    content_body %}
+<article itemscope="itemscope" 
+         itemtype="http://schema.org/{{page.schema_type|default('WebPage') }}">
+  <header>
+    <h1 itemprop="name headline">{{ page.title }}</h1>
+    {% if PDF_PROCESSOR %}
+    <a href="{{ SITEURL }}/pdf/{{ page.slug }}.pdf">PDF</a>
+    {% endif %}
+  </header>
+  <div class="content-body" itemprop="text">
+    {% if page.standfirst %}
+      <p class="standfirst" itemprop="description">{{ page.standfirst|e }}</p>
+    {% endif %}
+    {{ page.content }}
+  </div>
+
+  {% for file in CUSTOM_PAGE_FOOTERS %}
+    {% include "includes/" + file %}
+  {% endfor %}
+
+</article>
+{% endblock content_body %}
+
+{% block    content_footer %}
+{% if CUSTOM_CONTENT_BOTTOM_PAGE %}
+{% include "includes/" + CUSTOM_CONTENT_BOTTOM_PAGE %}
+{% endif %}
+{% endblock content_footer %}
+
+{% block    container_footer %}
+{% if CUSTOM_CONTAINER_BOTTOM_PAGE %}
+{% include "includes/" + CUSTOM_CONTAINER_BOTTOM_PAGE %}
+{% endif %}
+{% endblock container_footer %}
+
+{% block scripts %}
+  {% if CUSTOM_SCRIPTS_PAGE %}
+  {% include "includes/" + CUSTOM_SCRIPTS_PAGE %}
+  {% endif %}
+  {% if page.javascript %}
+    <script src="{{ SITEURL }}/theme/js/{{ page.javascript }}" ></script>
+  {% endif %}
+{% endblock %}

--- a/theme/voidy-bootstrap/templates/page.html
+++ b/theme/voidy-bootstrap/templates/page.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{ page.title }} - {{ SITENAME }}{% endblock %}
-{% block metadesc %}{% if page.description %}{{ page.description|e }}{% else %}A Page in {{ SITETAG }}: {{ page.title }}{% endif %}{% endblock %}
+{% block metadesc %}{% if page.description %}{{ page.description|e }}{% else %}{{ SITETAG }}: {{ page.title }}{% endif %}{% endblock %}
 {% block open_graph %}
 {% if OPEN_GRAPH %}
     <meta property="og:type" content="article"/>


### PR DESCRIPTION
'A page in' appears when the pages are linked, which is ugly. Delete it.