### PR TITLE
Delete_Preview: Fix of non-delete bug.

### DIFF
--- a/.github/workflows/delete_preview.yml
+++ b/.github/workflows/delete_preview.yml
@@ -43,18 +43,20 @@ jobs:
       run: |
         sh tools/init_output.sh
 
-    - name: Delete Preview & Make Link in the output directory
+    - name: Delete Preview & Make Link & Stage Changes in the output directory
       run: |
-        PREVIEW_DIR="./output/previews/${GITHUB_REF}"
+        PREVIEW_DIR="./previews/${GITHUB_REF}"
         TARGET_PATH="../"
-        if [ -e ${PREVIEW_DIR} ]; then
-          rm -rf "${PREVIEW_DIR}"
+        cd output/
+        if [ -e "${PREVIEW_DIR}" ]; then
+          git rm -r "${PREVIEW_DIR}"
           for s in `echo "${GITHUB_REF}" | fold -w1`; do
             if [ $s = '/' ]; then
               TARGET_PATH+="../"
             fi
           done
           ln -s ${TARGET_PATH} "${PREVIEW_DIR}"
+          git add "${PREVIEW_DIR}"
         fi
 
     - name: Deploy on Site
@@ -63,5 +65,4 @@ jobs:
         git config user.name $GITHUB_ACTOR
         git config --add url.github:.pushInsteadOf https://github.com/
         git config --add url.github:.pushInsteadOf git@github.com:
-        git add .
         git commit -m '$GITHUB_REF branch deleted.' && git push || true


### PR DESCRIPTION
In the preview system, there was a bug that previews are not deleted when the branch is deleted. This must be a problem of git staging, although I do not know the precise reason of that yet.
Anyway this patch is a more rigid way to do it.