### PR TITLE
Improve connections between pelicanconf.py & contentconf.py

### DIFF
--- a/content/contentconf.py
+++ b/content/contentconf.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*- #
 # site-specific settings
-import datetime
+import sys, os
+sys.path.append(os.curdir + '/..')
+from tools.lib.pelicanns import *
 
 GITHUB_ACCOUNT = 'oumpy'
 SOURCEREPOSITORY_NAME = 'hp_management'

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*- #
 from __future__ import unicode_literals
 import datetime
+import copy
 import os
 import sys
 sys.path.append(os.curdir)
@@ -164,6 +165,10 @@ JINJA_FILTERS += (('apply_jinja2', filter_apply_jinja2),)
 FILTER_APPLY_JINJA2 = True
 
 # Read user's custom settings.
+import tools.lib.pelicanns
+globals_copy = copy.copy(globals())
+for k, v in globals_copy.items():
+    setattr(tools.lib.pelicanns, k, v)
 from content.contentconf import *
 
 # Settings for Open Graph Properties


### PR DESCRIPTION
This patch enables on to use in contentconf the variables defined in pelicanconf.
For that purpose it added a dummy empty file tools/lib/pelicanns.py, than which I do not know a better method.