### PR TITLE
[URGENT] filename2slug: critical bugfix

### DIFF
--- a/myplugins/filename2slug/filename2slug.py
+++ b/myplugins/filename2slug/filename2slug.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def filename2slug(obj, settings):
-    if hasattr(obj.metadata, 'slug'):
+    if 'slug' in obj.metadata.keys():
         return
     
     source_path = obj.source_path


### PR DESCRIPTION
In #233 there was a critical bug that prefers filename than metadata as its slug. This changed index.html to about.html, deleting the very top-page of the site. This patch fixes it. Please approve & merge it as soon as possible.