### PR TITLE
Add article numbers to tag_cloud in the sidebar.

### DIFF
--- a/content/contentconf.py
+++ b/content/contentconf.py
@@ -99,5 +99,6 @@ for group in TAG_GROUPS:
         CUSTOM_TAG_BADGE_COLORS[tag] = group[2]
 import urllib.parse
 URL_ENCODED_GROUPNAMES = dict([ (group[0], urllib.parse.quote(group[0])) for group in TAG_GROUPS ])
+TAG_CLOUD_BADGE = True
 
 PREVIEW_SITENAME_APPEND = ' (テスト用ページ)'


### PR DESCRIPTION
Just turned on the built-in function of voidy-bootstrap theme.