### PR TITLE
Fix plugin filename2slug

### DIFF
--- a/myplugins/filename2slug/filename2slug.py
+++ b/myplugins/filename2slug/filename2slug.py
@@ -14,7 +14,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def filename2slug(obj, settings):
+def filename2slug(obj):
     if 'slug' in obj.metadata.keys():
         return
     
@@ -24,15 +24,5 @@ def filename2slug(obj, settings):
     obj.slug = filename_body
 
 
-def run_plugin(generators):
-    for generator in generators:
-        if isinstance(generator, ArticlesGenerator):
-            for article in generator.articles:
-                filename2slug(article, generator.settings)
-        elif isinstance(generator, PagesGenerator):
-            for page in generator.pages:
-                filename2slug(page, generator.settings)
-
-
 def register():
-    signals.all_generators_finalized.connect(run_plugin)
+    signals.content_object_init.connect(filename2slug)

--- a/myplugins/filename2slug/filename2slug.py
+++ b/myplugins/filename2slug/filename2slug.py
@@ -5,7 +5,6 @@ filename2slug Plugin for Pelican
 This plugin sets the filename of the source (not title) as the default slug for articles/pages.
 """
 
-from __future__ import unicode_literals
 from pelican import signals
 import os
 

--- a/myplugins/filename2slug/filename2slug.py
+++ b/myplugins/filename2slug/filename2slug.py
@@ -8,7 +8,6 @@ This plugin sets the filename of the source (not title) as the default slug for 
 from __future__ import unicode_literals
 from pelican import signals
 import os
-from pelican.generators import ArticlesGenerator, PagesGenerator
 
 import logging
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This patch corrects `filename2slug`, so that the default slugs are given at an earlier stage of compile. That erases potential errors in interferences with other plugins.