### PR TITLE
Bugfix on colab-link to jupyter notebooks.

### DIFF
--- a/theme/voidy-bootstrap/templates/includes/custom/header_article.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/header_article.html
@@ -1,5 +1,6 @@
     <meta name="article:slug" property="og:article:slug" content="{{ article.slug }}">
     <meta name="article:category" property="og:article:category" content="{{ article.category }}">
+    <meta name="article:category:slug" property="og:article:category:slug" content="{{ article.category.slug }}">
     <meta name="article:date" property="og:article:date" content="{{ article.date|strftime("%Y-%m-%d") }}">
 {% if article.modified %}
     <meta name="article:modified" property="og:article:modified" content="{{ article.modified|strftime("%Y-%m-%d") }}">

--- a/theme/voidy-bootstrap/templates/includes/custom/open_in_colab_scripts.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/open_in_colab_scripts.html
@@ -5,7 +5,7 @@ if (check_ipynb.length > 0) {
     var article_date = document.getElementsByName('article:date')[0].content;
     var article_year = article_date.slice(0, 4);
     var article_month = article_date.slice(5, 7);
-    var article_category = document.getElementsByName('article:category')[0].content; 
+    var article_category = document.getElementsByName('article:category:slug')[0].content; 
     if (parseInt(article_month) <= 3) {
       article_year = article_year - 1;
     }


### PR DESCRIPTION
Introduction of `category_name` plugin brought out a bug on on the colab-link. This patch corrects it and make the links alive again.

Note that this patch only works after merging #251.