### PR TITLE
Move postprocess from Makefile to Plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ INPUTDIR=$(BASEDIR)/content
 OUTPUTDIR=$(BASEDIR)/output
 CONFFILE=$(BASEDIR)/pelicanconf.py
 PUBLISHCONF=$(BASEDIR)/publishconf.py
-POSTPROCESS=$(BASEDIR)/content/postprocess.sh
 
 GITHUB_PAGES_BRANCH=master
 
@@ -42,8 +41,7 @@ help:
 	@echo '                                                                          '
 
 html:
-	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) &&\
-	[ -e $(POSTPROCESS) ] && sh $(POSTPROCESS) $(OUTPUTDIR)
+	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
 
 clean:
 	[ ! -d $(OUTPUTDIR) ] || rm -rf $(OUTPUTDIR)/*
@@ -74,8 +72,7 @@ else
 endif
 
 publish:
-	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(PUBLISHCONF) $(PELICANOPTS) &&\
-	[ -e $(POSTPROCESS) ] && sh $(POSTPROCESS) $(OUTPUTDIR)
+	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(PUBLISHCONF) $(PELICANOPTS)
 
 github: publish
 	ghp-import -m "Generate Pelican site" -b $(GITHUB_PAGES_BRANCH) $(OUTPUTDIR)

--- a/content/contentconf.py
+++ b/content/contentconf.py
@@ -102,3 +102,8 @@ URL_ENCODED_GROUPNAMES = dict([ (group[0], urllib.parse.quote(group[0])) for gro
 TAG_CLOUD_BADGE = True
 
 PREVIEW_SITENAME_APPEND = ' (テスト用ページ)'
+
+PLUGINS += [
+    'postprocess',
+]
+POSTPROCESS_COMMAND = 'sh content/postprocess.sh'

--- a/myplugins/postprocess.py
+++ b/myplugins/postprocess.py
@@ -1,0 +1,21 @@
+"""
+Postprocess Plugin for Pelican
+-------
+
+This plugin runs a postprocess command after finishing complile.
+"""
+
+from pelican import signals
+import subprocess
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def run_postprocess(pelicanobj):
+    command = pelicanobj.settings['POSTPROCESS_COMMAND']
+    output = pelicanobj.settings['OUTPUT_PATH']
+    subprocess.run(command.split() + [ output ])
+
+def register():
+    signals.finalized.connect(run_postprocess)


### PR DESCRIPTION
So far, postprocessing script `content/postprocess.sh` (making symbolic links) was called from Makefile. This patch introduces a new simple plugin `postprocess`, which can call arbitrary postprocessing script by a very simple configuration. In a setting in contentconf, it calls `postprocess.sh`.