### PR TITLE
Enable to deal articles/pages as Jinja2 templates

### DIFF
--- a/myplugins/apply_jinja2.py
+++ b/myplugins/apply_jinja2.py
@@ -24,12 +24,12 @@ def configure(generators):
             for article in generator.articles:
                 if metadata_field in article.metadata and bool(article.metadata[metadata_field]):
                     template = jinja2.Template(article.content)
-                    article.content = template.render(**variables)
+                    article._content = template.render(**variables)
         elif isinstance(generator, PagesGenerator):
             for page in generator.pages:
                 if metadata_field in page.metadata and bool(page.metadata[metadata_field]):
                     template = jinja2.Template(page.content)
-                    page.content = template.render(**variables)
+                    page._content = template.render(**variables)
 
 def filter_apply_jinja2(content):
     env = jinja2.Environment(loader=jinja2.DictLoader({'content': content}))

--- a/myplugins/apply_jinja2.py
+++ b/myplugins/apply_jinja2.py
@@ -23,12 +23,16 @@ def configure(generators):
         if isinstance(generator, ArticlesGenerator):
             for article in generator.articles:
                 if metadata_field in article.metadata and bool(article.metadata[metadata_field]):
-                    template = jinja2.Template(article.content)
+                    env = jinja2.Environment(loader=jinja2.DictLoader({'content': article.content}))
+                    env.filters.update(variables['JINJA_FILTERS'])
+                    template = env.get_template('content')
                     article._content = template.render(**variables)
         elif isinstance(generator, PagesGenerator):
             for page in generator.pages:
                 if metadata_field in page.metadata and bool(page.metadata[metadata_field]):
-                    template = jinja2.Template(page.content)
+                    env = jinja2.Environment(loader=jinja2.DictLoader({'content': page.content}))
+                    env.filters.update(variables['JINJA_FILTERS'])
+                    template = env.get_template('content')
                     page._content = template.render(**variables)
 
 def filter_apply_jinja2(content):

--- a/myplugins/apply_jinja2.py
+++ b/myplugins/apply_jinja2.py
@@ -19,20 +19,17 @@ metadata_field = 'jinja2'
 def configure(generators):
     for generator in generators:
         variables.update(generator.context)
+    for generator in generators:
         if isinstance(generator, ArticlesGenerator):
             for article in generator.articles:
                 if metadata_field in article.metadata and bool(article.metadata[metadata_field]):
-                    var = copy(variables)
-                    var.update(article.context)
                     template = jinja2.Template(article.content)
-                    article.content = template.render(**var)
+                    article.content = template.render(**variables)
         elif isinstance(generator, PagesGenerator):
             for page in generator.pages:
                 if metadata_field in page.metadata and bool(page.metadata[metadata_field]):
-                    var = copy(variables)
-                    var.update(page.context)
                     template = jinja2.Template(page.content)
-                    page.content = template.render(**var)
+                    page.content = template.render(**variables)
 
 def filter_apply_jinja2(content):
     env = jinja2.Environment(loader=jinja2.DictLoader({'content': content}))

--- a/myplugins/apply_jinja2.py
+++ b/myplugins/apply_jinja2.py
@@ -18,7 +18,9 @@ def configure(generators):
         variables.update(generator.context)
 
 def filter_apply_jinja2(content):
-    template = jinja2.Template(content)
+    env = jinja2.Environment(loader=jinja2.DictLoader({'content': content}))
+    env.filters.update(variables['JINJA_FILTERS'])
+    template = env.get_template('content')
     result = template.render(**variables)
     return result
 

--- a/myplugins/apply_jinja2.py
+++ b/myplugins/apply_jinja2.py
@@ -8,7 +8,6 @@ This plugin provides a filter to apply jinja2.
 from pelican import signals
 from pelican.generators import ArticlesGenerator, PagesGenerator
 import jinja2
-from copy import copy
 
 import logging
 logger = logging.getLogger(__name__)

--- a/myplugins/apply_jinja2.py
+++ b/myplugins/apply_jinja2.py
@@ -1,0 +1,34 @@
+"""
+ApplyJinja2 Plugin for Pelican
+-------
+
+This plugin provides a filter to apply jinja2.
+"""
+
+from pelican import signals
+import jinja2
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+variables = dict()
+def configure(generators):
+    for generator in generators:
+        variables.update(generator.context)
+
+def filter_apply_jinja2(content):
+    template = jinja2.Template(content)
+    result = template.render(**variables)
+    return result
+
+def initialize(pelicanobj):
+    settings = pelicanobj.settings
+    if not 'JINJA_FILTERS' in settings:
+        settings['JINJA_FILTERS'] = dict()
+    settings['JINJA_FILTERS']['apply_jinja2'] = filter_apply_jinja2
+    settings['FILTER_APPLY_JINJA2'] = True
+
+def register():
+    signals.initialized.connect(initialize)
+    signals.all_generators_finalized.connect(configure)

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -69,6 +69,7 @@ PLUGINS = [
     'category_names',
     'shortcodes',
     'filename2slug',
+    'apply_jinja2',
 ]
 
 RELATED_POSTS_MAX = 3
@@ -149,21 +150,6 @@ CUSTOM_RECENTPOSTS_TITLE = '新着記事'
 TWITTER_CARD = True
 OPEN_GRAPH = True
 
-JINJA_FILTERS = ()
-import jinja2
-def filter_apply_jinja2(content,tags,siteurl):
-    template = jinja2.Template(content)
-    variables = dict()
-    variables.update(globals())
-    variables.update(locals())
-    variables.update({
-        'SITEURL' : siteurl,
-        'tags' : tags,
-    })
-    result = template.render(**variables)
-    return result
-JINJA_FILTERS += (('apply_jinja2', filter_apply_jinja2),)
-FILTER_APPLY_JINJA2 = True
 
 # Read user's custom settings.
 import tools.lib.pelicanns

--- a/theme/voidy-bootstrap/templates/includes/custom/content_top_category.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/content_top_category.html
@@ -6,7 +6,7 @@
 {% set cat = category.slug %}
 {% if CATEGORY_CONTENTS is defined and cat in CATEGORY_CONTENTS and output_file == page_name+'.html' %}
   {% if FILTER_APPLY_JINJA2|default(false) %}
-    {{ CATEGORY_CONTENTS[cat]|apply_jinja2(tags,SITEURL) }}
+    {{ CATEGORY_CONTENTS[cat]|apply_jinja2 }}
   {% else %}
     {{ CATEGORY_CONTENTS[cat] }}
   {% endif %}


### PR DESCRIPTION
By setting `Jinja2: True` in metadata, this patch deals the article/page as a Jinja2 template, in which you can use almost all variables that are provided for theme templates.

This PR should be reviewed after #253 is successfully merged.