### PR TITLE
pelicanconf: Comment out `PAGE_ORDER_BY = 'page_order'`

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -24,7 +24,7 @@ DATE_FORMATS = {
     'ja': '%Y-%m-%d(%a)',
 }
 
-PAGE_ORDER_BY = 'page_order'
+# PAGE_ORDER_BY = 'page_order'
 
 start_year = 2017
 this_year = datetime.date.today().year


### PR DESCRIPTION
Since the order is now set manually in contentconf.py, `page_order` setting is no longer necessary.