### PR TITLE
Use `makemenu` for menubar, activating articles correctly.

### DIFF
--- a/content/contentconf.py
+++ b/content/contentconf.py
@@ -3,6 +3,9 @@
 import sys, os
 sys.path.append(os.curdir + '/..')
 from tools.lib.pelicanns import *
+for pluginpath in PLUGIN_PATHS:
+    sys.path.append(os.curdir + '/' + pluginpath)
+from makemenu import MenuItem
 
 GITHUB_ACCOUNT = 'oumpy'
 SOURCEREPOSITORY_NAME = 'hp_management'
@@ -69,15 +72,19 @@ CATEGORYNAMES_ALTERNATIVES = {
     'news': ('お知らせ', 'Python会からのお知らせ'),
     'blog': ('技術ブログ',),
 }
+
 ADD_ON_MENU = (
-    ('Python会について', 'index.html'),
-    ('活動内容', 'activities.html'),
-    ('実績', 'achievements.html'),
-    (CATEGORYNAMES_ALTERNATIVES['blog'][0], 'blog.html'),
-    (CATEGORYNAMES_ALTERNATIVES['news'][0], 'news.html'),
-    ('会員募集', 'recruit.html'),
-    ('Contact', 'contact.html'),
+    MenuItem('index.html'),
+    MenuItem('activities.html'),
+    MenuItem('achievements.html'),
+    MenuItem('blog.html', title=CATEGORYNAMES_ALTERNATIVES['blog'][0],
+             active_pages=r'(blog/|tag/(?!news).+\.html$|author/(?!pythonhui).+\.html$)'),
+    MenuItem('news.html', title=CATEGORYNAMES_ALTERNATIVES['news'][0],
+             active_pages=r'(news/|tag/news\.html$|author/pythonhui\.html$)'),
+    MenuItem('recruit.html'),
+    MenuItem('contact.html'),
 )
+
 HIDE_ARCHIVES_ON_MENU = True
 SHOW_FEED_ATOM_ON_MENU = SHOW_FEED_RSS_ON_MENU = False
 SIDEBAR_HIDE_CATEGORIES = True

--- a/myplugins/makemenu.py
+++ b/myplugins/makemenu.py
@@ -38,6 +38,11 @@ def makemenu(add_on_menu, page_url, depth=1, CARET=False):
 # page_url: give the url of the page where this filter is called
 # depath: depth of the menu hierarchy
     ret = []
+    page_depth = page_url.count('/')
+    if page_depth == 0:
+        rooturl = '.'
+    else:
+        rooturl = '../' * (page_depth-1) + '..' 
     FORWARD, BACK = 0, 1
     for obj in add_on_menu:
         pool = [(obj, 0, FORWARD, {'parent':None})]
@@ -75,7 +80,7 @@ def makemenu(add_on_menu, page_url, depth=1, CARET=False):
                     a_format = '<a href="{}">{}{}</a>'
                 else:
                     a_format = '<a href="{}">{}{}</a>'
-                ret.append(a_format.format('./{}'.format(node.url), title, caret))
+                ret.append(a_format.format('{}/{}'.format(rooturl, node.url), title, caret))
 
                 if len(subsections) > 0:
                     ret.append('<ul>')

--- a/myplugins/makemenu.py
+++ b/myplugins/makemenu.py
@@ -1,0 +1,105 @@
+"""
+MakeMenu Plugin for Pelican
+-------
+
+This plugin provides a filter to generate submenus list.
+"""
+
+from __future__ import unicode_literals
+from pelican import signals
+from collections import defaultdict
+import re
+import sys, os
+
+import logging
+logger = logging.getLogger(__name__)
+
+filter_url2obj = None
+
+def initialize(pelicanobj):
+    global filter_url2obj
+    settings = pelicanobj.settings
+    if 'url2obj' in settings['JINJA_FILTERS'].keys():
+        filter_url2obj = settings['JINJA_FILTERS']['url2obj']
+    settings['JINJA_FILTERS']['makemenu'] = makemenu
+
+
+class MenuItem():
+    def __init__(self, url, title=None, subsections=[], active_pages=None):
+        self.url, self.title, self.active_pages = url, title, active_pages
+        if subsections == []:
+            self.subsections = []
+        else:
+            self.subsections = subsections
+    AUTO = None
+
+def makemenu(add_on_menu, page_url, depth=1, CARET=False):
+# add_on_menu : list or tuple of MenuItem objects
+# page_url: give the url of the page where this filter is called
+# depath: depth of the menu hierarchy
+    ret = []
+    FORWARD, BACK = 0, 1
+    for obj in add_on_menu:
+        pool = [(obj, 0, FORWARD, {'parent':None})]
+        active_flag = defaultdict(bool)
+        active_flag[page_url] = True
+        while pool:
+            node, d, s, params = pool.pop()
+            if isinstance(node, str):
+                if filter_url2obj:
+                    node = filter_url2obj(node)
+                else:
+                    logger.error('You need path2obj for \'{}\' in submenu.'.format(node))
+            if not hasattr(node, 'subsections') or node.subsections is None:
+                if filter_url2obj:
+                    subsections = filter_url2obj(node.url).subsections
+                else:
+                    subsections = []
+            else:
+                subsections = node.subsections
+            if node.title is None and filter_url2obj:
+                title = filter_url2obj(node.url).title
+            else:
+                title = node.title
+
+            if s == FORWARD:
+                if d >= depth:
+                    subsections = []
+
+                params['li_line'] = len(ret)
+                ret.append('<li>')
+                caret = ''
+                if d == 0:
+                    if subsections and CARET:
+                        caret = ' <span class="caret"></span>'
+                    a_format = '<a href="{}">{}{}</a>'
+                else:
+                    a_format = '<a href="{}">{}{}</a>'
+                ret.append(a_format.format('./{}'.format(node.url), title, caret))
+
+                if len(subsections) > 0:
+                    ret.append('<ul>')
+                    params['/ul'] = True
+                    pool.append((node, d, BACK, params))
+                    for c in subsections[::-1]:
+                        pool.append((c, d+1, FORWARD, {'parent':node.url}))
+                else:
+                    params['/ul'] = False
+                    pool.append((node, d, BACK, params))
+            else: # s==BACK
+                if params['/ul']:
+                    ret.append('</ul></li>')
+                else:
+                    ret.append('</li>')
+                active_flag[node.url] |= bool(
+                    hasattr(node,'active_pages') and node.active_pages and re.match(node.active_pages, page_url)
+                )
+                if active_flag[node.url]:
+                    ret[params['li_line']] = ret[params['li_line']][:-1] + ' class="active">'
+                    active_flag[params['parent']] = True
+
+    return '\n'.join(ret)
+
+
+def register():
+    signals.get_generators.connect(initialize)

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -70,6 +70,8 @@ PLUGINS = [
     'category_names',
     'shortcodes',
     'apply_jinja2',
+    'path2obj',
+    'makemenu',
 ]
 
 RELATED_POSTS_MAX = 3

--- a/theme/voidy-bootstrap/templates/base.html
+++ b/theme/voidy-bootstrap/templates/base.html
@@ -105,15 +105,14 @@
             {% endfor %}
           {% endif %}
           {% if ADD_ON_MENU %}
-            {% for item in ADD_ON_MENU %}
-              {% if ( page_name is defined and page_name+'.html' == item.1 ) or ( page is defined and page.url == item.1 ) %}
-              <li class="active">
-              {% else %}
-              <li>
-              {% endif %}
-                <a href="{{ SITEURL }}/{{ item.1 }}">{{ item.0 }}</a>
-              </li>
-            {% endfor %}
+            {% if page_name is defined %}
+              {% set thispage_url = page_name+'.html' %}
+            {% elif page is defined %}
+              {% set thispage_url = page.url %}
+            {% elif article is defined %}
+              {% set thispage_url = article.url %}
+            {% endif %}
+            {{ ADD_ON_MENU|makemenu(thispage_url, 0) }}
           {% endif %}
           {% if not HIDE_ARCHIVES_ON_MENU %}
             <li class="divider"></li>
@@ -121,7 +120,9 @@
               <a href="{{ SITEURL }}/{{ ARCHIVES_URL|default('archives.html') }}">Archives</a>
             </li>
           {% endif %}
+          {% if (FEED_ALL_ATOM and SHOW_FEED_ATOM_ON_MENU|default(true)) or (FEED_ALL_RSS and SHOW_FEED_RSS_ON_MENU|default(false)) %}
           <li class="divider"></li>
+          {% endif %}
           {% if FEED_ALL_ATOM and SHOW_FEED_ATOM_ON_MENU|default(true) %}
             <li><a href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" 
                    type="application/atom+xml" rel="alternate">


### PR DESCRIPTION
This patch imports only some part of #237, including the `makemenu` plugin.
It does NOT introduce advanced multi-hierarchal menu. The appearance will not be changed almost at all.

The major merit is that the menu items are more appropriately highlighted. Currently, the menu '技術ブログ' is not highlighted for individual blog articles. Similar for individual news. The high customizability of the `makemenu` plugin resolves the problem.

The remaining part of the advanced menu system will be still left in #237. The appearance problem of multi-hierarchal menu is not resolved yet there.