### PR TITLE
Bugfix on menu-link in paginated lists.

### DIFF
--- a/theme/voidy-bootstrap/templates/base.html
+++ b/theme/voidy-bootstrap/templates/base.html
@@ -120,14 +120,7 @@
             {% endfor %}
           {% endif %}
           {% if ADD_ON_MENU %}
-            {% if page_name is defined %}
-              {% set thispage_url = page_name+'.html' %}
-            {% elif page is defined %}
-              {% set thispage_url = page.url %}
-            {% elif article is defined %}
-              {% set thispage_url = article.url %}
-            {% endif %}
-            {{ ADD_ON_MENU|makemenu(thispage_url, MENU_STEPS|default(1)) }}
+            {{ ADD_ON_MENU|makemenu(output_file, MENU_STEPS|default(1)) }}
           {% endif %}
           {% if not HIDE_ARCHIVES_ON_MENU %}
             <li class="divider"></li>


### PR DESCRIPTION
In 2nd, 3rd,... pages of article lists, the menu link of blog is dead. This patch fixes the bug.