### PR TITLE
Plugin/excludes_dirnames

### DIFF
--- a/content/contentconf.py
+++ b/content/contentconf.py
@@ -6,6 +6,7 @@ from tools.lib.pelicanns import *
 for pluginpath in PLUGIN_PATHS:
     sys.path.append(os.curdir + '/' + pluginpath)
 from makemenu import MenuItem
+import pathlib
 
 LANG = 'ja'
 
@@ -134,10 +135,15 @@ TAG_CLOUD_BADGE = True
 
 PREVIEW_SITENAME_APPEND = ' (テスト用ページ)'
 
+Exclude_DirNames = ['attach']
 if not 'ARTICLE_EXCLUDES' in globals(): ARTICLE_EXCLUDES = []
-start_year = 2017
-this_year = datetime.date.today().year
-ARTICLE_EXCLUDES += [ 'articles/{}sy/{}/attach'.format(y,cat) for cat in {'blog', 'news'} for y in range(start_year, this_year+2) ]
+ARTICLE_EXCLUDES += [
+    os.path.relpath(dir, PATH)
+    for root in ARTICLE_PATHS
+        for dirname in Exclude_DirNames
+            for dir in pathlib.Path(PATH).glob(os.path.join(root, '**/{}'.format(dirname)))
+                if dir.is_dir()
+]
 PLUGINS += [
     'postprocess',
 ]

--- a/content/contentconf.py
+++ b/content/contentconf.py
@@ -136,14 +136,19 @@ TAG_CLOUD_BADGE = True
 PREVIEW_SITENAME_APPEND = ' (テスト用ページ)'
 
 Exclude_DirNames = ['attach']
+if not 'PATH' in globals(): PATH = ['content']
+if not 'ARTICLE_PATHS' in globals(): ARTICLE_PATHS = ['articles']
+if not 'PAGE_PATHS' in globals(): PAGE_PATHS = ['pages']
 if not 'ARTICLE_EXCLUDES' in globals(): ARTICLE_EXCLUDES = []
-ARTICLE_EXCLUDES += [
-    os.path.relpath(dir, PATH)
-    for root in ARTICLE_PATHS
-        for dirname in Exclude_DirNames
-            for dir in pathlib.Path(PATH).glob(os.path.join(root, '**/{}'.format(dirname)))
-                if dir.is_dir()
-]
+if not 'PAGE_EXCLUDES' in globals(): PAGE_EXCLUDES = []
+for excludes, paths in [(ARTICLE_EXCLUDES, ARTICLE_PATHS), (PAGE_EXCLUDES, PAGE_PATHS)]:
+    excludes += [
+        os.path.relpath(dir, PATH)
+        for root in paths
+            for dirname in Exclude_DirNames
+                for dir in pathlib.Path(PATH).glob(os.path.join(root, '**/{}'.format(dirname)))
+                    if dir.is_dir()
+    ]
 PLUGINS += [
     'postprocess',
 ]

--- a/content/contentconf.py
+++ b/content/contentconf.py
@@ -135,6 +135,8 @@ TAG_CLOUD_BADGE = True
 PREVIEW_SITENAME_APPEND = ' (テスト用ページ)'
 
 if not 'ARTICLE_EXCLUDES' in globals(): ARTICLE_EXCLUDES = []
+start_year = 2017
+this_year = datetime.date.today().year
 ARTICLE_EXCLUDES += [ 'articles/{}sy/{}/attach'.format(y,cat) for cat in {'blog', 'news'} for y in range(start_year, this_year+2) ]
 PLUGINS += [
     'postprocess',

--- a/content/contentconf.py
+++ b/content/contentconf.py
@@ -136,11 +136,15 @@ TAG_CLOUD_BADGE = True
 PREVIEW_SITENAME_APPEND = ' (テスト用ページ)'
 
 Exclude_DirNames = ['attach']
-if not 'PATH' in globals(): PATH = ['content']
-if not 'ARTICLE_PATHS' in globals(): ARTICLE_PATHS = ['articles']
-if not 'PAGE_PATHS' in globals(): PAGE_PATHS = ['pages']
-if not 'ARTICLE_EXCLUDES' in globals(): ARTICLE_EXCLUDES = []
-if not 'PAGE_EXCLUDES' in globals(): PAGE_EXCLUDES = []
+defaults = {
+    'PATH' : ['content'],
+    'ARTICLE_PATHS' : ['articles'],
+    'PAGE_PATHS' : ['pages'],
+    'ARTICLE_EXCLUDES' : [],
+    'PAGE_EXCLUDES' : [],
+}
+for variable, value in defaults.items():
+    if not variable in globals(): globals()[variable] = value
 for excludes, paths in [(ARTICLE_EXCLUDES, ARTICLE_PATHS), (PAGE_EXCLUDES, PAGE_PATHS)]:
     excludes += [
         os.path.relpath(dir, PATH)

--- a/content/contentconf.py
+++ b/content/contentconf.py
@@ -6,7 +6,6 @@ from tools.lib.pelicanns import *
 for pluginpath in PLUGIN_PATHS:
     sys.path.append(os.curdir + '/' + pluginpath)
 from makemenu import MenuItem
-import pathlib
 
 LANG = 'ja'
 
@@ -135,24 +134,6 @@ TAG_CLOUD_BADGE = True
 
 PREVIEW_SITENAME_APPEND = ' (テスト用ページ)'
 
-Exclude_DirNames = ['attach']
-defaults = {
-    'PATH' : ['content'],
-    'ARTICLE_PATHS' : ['articles'],
-    'PAGE_PATHS' : ['pages'],
-    'ARTICLE_EXCLUDES' : [],
-    'PAGE_EXCLUDES' : [],
-}
-for variable, value in defaults.items():
-    if not variable in globals(): globals()[variable] = value
-for excludes, paths in [(ARTICLE_EXCLUDES, ARTICLE_PATHS), (PAGE_EXCLUDES, PAGE_PATHS)]:
-    excludes += [
-        os.path.relpath(dir, PATH)
-        for root in paths
-            for dirname in Exclude_DirNames
-                for dir in pathlib.Path(PATH).glob(os.path.join(root, '**/{}'.format(dirname)))
-                    if dir.is_dir()
-    ]
 PLUGINS += [
     'postprocess',
 ]

--- a/myplugins/excludes_dirnames.py
+++ b/myplugins/excludes_dirnames.py
@@ -26,7 +26,7 @@ def defaultsettings(pelicanobj):
 def run_plugin(pelicanobj):
     defaultsettings(pelicanobj)
     settings = pelicanobj.settings
-    PATH = settings['PATH']
+    PATH = settings['PATH'] if 'PATH' in settings else './'
     variable_sets = [
         ('ARTICLE_EXCLUDES', 'ARTICLE_PATHS', 'ARTICLE_EXCLUDES_DIRNAMES'), 
         ('PAGE_EXCLUDES', 'PAGE_PATHS', 'PAGE_EXCLUDES_DIRNAMES'),

--- a/myplugins/excludes_dirnames.py
+++ b/myplugins/excludes_dirnames.py
@@ -1,0 +1,46 @@
+"""
+ExcludesDirnames Plugin for Pelican
+-------
+
+This plugin provides setting parameters,
+ARTICLE_EXCLUDES_DIRNAMES, PAGE_EXCLUDES_DIRNAMES and STATIC_EXCLUDES_DIRNAMES.
+"""
+
+from __future__ import unicode_literals
+from pelican import signals
+import os, pathlib
+
+import logging
+logger = logging.getLogger(__name__)
+
+def defaultsettings(pelicanobj):
+    from pelican.settings import DEFAULT_CONFIG
+    DEFAULT_CONFIG.setdefault('ARTICLE_EXCLUDES_DIRNAMES', [])
+    DEFAULT_CONFIG.setdefault('PAGE_EXCLUDES_DIRNAMES', [])
+    DEFAULT_CONFIG.setdefault('STATIC_EXCLUDES_DIRNAMES', [])
+    if pelicanobj:
+        pelicanobj.settings.setdefault('ARTICLE_EXCLUDES_DIRNAMES', [])
+        pelicanobj.settings.setdefault('PAGE_EXCLUDES_DIRNAMES', [])
+        pelicanobj.settings.setdefault('STATIC_EXCLUDES_DIRNAMES', [])
+
+def run_plugin(pelicanobj):
+    defaultsettings(pelicanobj)
+    settings = pelicanobj.settings
+    PATH = settings['PATH']
+    variable_sets = [
+        ('ARTICLE_EXCLUDES', 'ARTICLE_PATHS', 'ARTICLE_EXCLUDES_DIRNAMES'), 
+        ('PAGE_EXCLUDES', 'PAGE_PATHS', 'PAGE_EXCLUDES_DIRNAMES'),
+        ('STATIC_EXCLUDES', 'STATIC_PATHS', 'STATIC_EXCLUDES_DIRNAMES'),
+    ]
+
+    for excludes, paths, dirnames in variable_sets:
+        settings[excludes] += [
+            os.path.relpath(dir, PATH)
+            for root in settings[paths]
+                for dirname in settings[dirnames]
+                    for dir in pathlib.Path(PATH).glob(os.path.join(root, '**/{}'.format(dirname)))
+                        if dir.is_dir()
+        ]
+
+def register():
+    signals.initialized.connect(run_plugin)

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -28,8 +28,6 @@ DATE_FORMATS = {
 
 # PAGE_ORDER_BY = 'page_order'
 
-start_year = 2017
-this_year = datetime.date.today().year
 ARTICLE_PATHS = ['articles']
 ARTICLE_SAVE_AS = ARTICLE_URL ='{category}/{date:%Y}/{date:%m}/{slug}.html'
 PAGE_SAVE_AS = PAGE_URL ='{slug}.html'

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -32,6 +32,7 @@ ARTICLE_PATHS = ['articles']
 ARTICLE_SAVE_AS = ARTICLE_URL ='{category}/{date:%Y}/{date:%m}/{slug}.html'
 PAGE_SAVE_AS = PAGE_URL ='{slug}.html'
 CATEGORY_SAVE_AS = CATEGORY_URL = '{slug}.html'
+ARTICLE_EXCLUDES_DIRNAMES = PAGE_EXCLUDES_DIRNAMES = ['attach', 'images']
 INDEX_SAVE_AS = 'articles.html'
 
 SLUGIFY_SOURCE = 'basename'
@@ -72,6 +73,7 @@ PLUGINS = [
     'subsections',
     'makemenu',
     'pelican-sass',
+    'excludes_dirnames',
 ]
 
 RELATED_POSTS_MAX = 3


### PR DESCRIPTION
This patch introduces a new plugin excludes_dirnames, which enables the use of parameters `ARTICLE_EXCLUDES_DIRNAMES`, `PAGE_EXCLUDES_DIRNAMES` & `STATIC_EXCLUDES_DIRNAMES`. They make it much easier to control which directories should be processed or not, and the configuration files become simpler, easier to read and stronger against changes.