### PR TITLE
Delete unnecessary metadata from pages

### DIFF
--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -2,7 +2,6 @@ Title: Python会について
 Date: 2020.03.13
 Modified: 2020.03.24
 Slug: index
-Author: Python会
 Summary: Python会の紹介ページです。
 
 Python会とは、大阪大学医学部の学生が中心となり、プログラミング言語Pythonを軸に、医療分野と絡めて個人の研究・趣味に取り組む会です。

--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -3,7 +3,6 @@ Date: 2020.03.13
 Modified: 2020.03.24
 Slug: index
 Author: Python会
-Page_order: 100
 Summary: Python会の紹介ページです。
 
 Python会とは、大阪大学医学部の学生が中心となり、プログラミング言語Pythonを軸に、医療分野と絡めて個人の研究・趣味に取り組む会です。

--- a/content/pages/achievements.md
+++ b/content/pages/achievements.md
@@ -3,7 +3,6 @@ Date: 2020.03.13
 Modified: 2020.03.24
 Show_modified: True
 Author: Python会
-Page_order: 200
 Summary: Python会の実績紹介
 
 ## 勉強会・成果発表活動

--- a/content/pages/achievements.md
+++ b/content/pages/achievements.md
@@ -2,7 +2,6 @@ Title: 実績
 Date: 2020.03.13
 Modified: 2020.03.24
 Show_modified: True
-Author: Python会
 Summary: Python会の実績紹介
 
 ## 勉強会・成果発表活動

--- a/content/pages/activities.md
+++ b/content/pages/activities.md
@@ -3,7 +3,6 @@ Date: 2020.03.15
 Modified: 2020.03.22
 Show_modified: True
 Author: Python会
-Page_order: 150
 Summary: Python会の活動内容紹介
 
 ## 学習・研究

--- a/content/pages/activities.md
+++ b/content/pages/activities.md
@@ -2,7 +2,6 @@ Title: 活動内容
 Date: 2020.03.15
 Modified: 2020.03.22
 Show_modified: True
-Author: Python会
 Summary: Python会の活動内容紹介
 
 ## 学習・研究

--- a/content/pages/constitution.md
+++ b/content/pages/constitution.md
@@ -1,7 +1,6 @@
 Title: 大阪大学医学部Python会規約 
 Date: 2020.04.01
 Modified: 2020.04.01
-Author: Python会
 Summary: 会規約の全文 (第1条〜第11条)
 
 ## 第1条（名称）

--- a/content/pages/constitution.md
+++ b/content/pages/constitution.md
@@ -2,7 +2,6 @@ Title: 大阪大学医学部Python会規約
 Date: 2020.04.01
 Modified: 2020.04.01
 Author: Python会
-Page_order: 130
 Summary: 会規約の全文 (第1条〜第11条)
 
 ## 第1条（名称）

--- a/content/pages/contact.md
+++ b/content/pages/contact.md
@@ -2,7 +2,6 @@ Title: Contact
 Date: 2020.03.13
 Modified: 2020.03.17
 Author: Python会
-Page_order: 400
 Summary: Python会への連絡用メールフォーム
 
 <!-- ![]({attach}images/computer-1209641_960_7201.jpg) -->

--- a/content/pages/contact.md
+++ b/content/pages/contact.md
@@ -1,7 +1,6 @@
 Title: Contact
 Date: 2020.03.13
 Modified: 2020.03.17
-Author: Python会
 Summary: Python会への連絡用メールフォーム
 
 <!-- ![]({attach}images/computer-1209641_960_7201.jpg) -->

--- a/content/pages/recruit.md
+++ b/content/pages/recruit.md
@@ -3,7 +3,6 @@ Date: 2020.03.13
 Modified: 2020.05.26
 Show_modified: True
 Author: Python会
-Page_order: 350
 Summary: Python会は学年学部問わず会員を募集しています。
 
 Python会は現在、学年学部問わず会員を募集しております。

--- a/content/pages/recruit.md
+++ b/content/pages/recruit.md
@@ -2,7 +2,6 @@ Title: 会員募集
 Date: 2020.03.13
 Modified: 2020.05.26
 Show_modified: True
-Author: Python会
 Summary: Python会は学年学部問わず会員を募集しています。
 
 Python会は現在、学年学部問わず会員を募集しております。

--- a/content/pages/search.md
+++ b/content/pages/search.md
@@ -1,7 +1,6 @@
 Title: 検索結果
 Date: 2020.05.18
 Modified: 2020.05.18
-Author: Python会
 Jinja2: True
 
 <script async src="https://cse.google.com/cse.js?cx={{ GOOGLE_CSE_ID }}"></script>


### PR DESCRIPTION
This patch deletes metadata `author` & `page_order` in pages, which are not used and not necessary.