### PR TITLE
scrolltop_scripts: minor correction.

### DIFF
--- a/theme/voidy-bootstrap/templates/includes/custom/scrolltop_scripts.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/scrolltop_scripts.html
@@ -1,7 +1,7 @@
-<p class="pagetop"><a href="#wrap"></a></p>
+<p class="pagetop" id="pagetop"><a href="#wrap"></a></p>
 <script>
 $(document).ready(function() {
-    var pagetop = $('.pagetop');
+    var pagetop = $('#pagetop');
     $(window).scroll(function () {
         if ($(this).scrollTop() > 600) {
             pagetop.fadeIn();


### PR DESCRIPTION
Use id, rather than a class.