### PR TITLE
Debug of the breakdown of sb_social feed links in deeper pages

### DIFF
--- a/theme/voidy-bootstrap/templates/includes/custom/sb_social.html
+++ b/theme/voidy-bootstrap/templates/includes/custom/sb_social.html
@@ -7,7 +7,11 @@
 <div class="box-contents">
 <ul class="list-unstyled social-links">
   {% for name, link, icon, color, size in SOCIAL %}
+    {% if link[:2] == './' %}
+  <li><a href="{{ SITEURL }}/{{ link[2:] }}" target="_blank" title="{{ name }}">
+    {% else %}
   <li><a href="{{ link }}" target="_blank" title="{{ name }}">
+    {% endif %}
     <span style="color:{{ color }}; font-size:{{ size }};">{{ icon }}<span>
   </a></li>
   {% endfor %}


### PR DESCRIPTION
Feed links were dead in deeper pages, such as articles. This patch corrects it in a rather ad-hoc way. It may not be the best but it works.