### PR TITLE
Sitemap: Make weight larger for pages.

### DIFF
--- a/content/contentpublishconf.py
+++ b/content/contentpublishconf.py
@@ -11,7 +11,7 @@ SITEMAP = {
     'priorities': {
         'articles': 0.5,
         'indexes': 0.1,
-        'pages': 0.5
+        'pages': 1.0,
     },
     'changefreqs': {
         'articles': 'weekly',


### PR DESCRIPTION
In Google searches, it seems that the indexing is not working in a nice manner. I'm not very sure on the cause but anyway the pages should have larger weight than articles in general.