### PR TITLE
Resolve the bug of ipynb articles by downgrading nbconvert.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pelican
 Markdown
-nbconvert
+nbconvert==5.6.1
 IPython
 beautifulsoup4
 requests


### PR DESCRIPTION
This PR fixes the bug #353, restoring the lost articles written as ipynb.

After a strugglement, I finally discovered that this bug comes from an incompatibility of the new version 6 of nbconvert to the older one, v5.6.
This patch fixes nbconvert==5.6.1, keeping it compatible with the pelican plugin.

Note that this is just an urgent first-aid, and in the future the plugin will also upgraded and we should update our code again at that time.