### PR TITLE
Update some plugins to newer-style (Pelican >= 4.5)

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -64,11 +64,12 @@ MARKUP = ['md', 'ipynb']
 
 PLUGIN_PATHS = ['./plugins', './myplugins']
 from pelican_jupyter import markup as nb_markup
+from pelican.plugins import render_math, tag_cloud, related_posts
 PLUGINS = [
     nb_markup,
-    'render_math',
-    'tag_cloud',
-    'related_posts',
+    render_math,
+    tag_cloud,
+    related_posts,
     'autosummary', 'summary', # this order is important!
     'category_names',
     'shortcodes',

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -63,8 +63,9 @@ CUSTOM_CONTENT_TOP_CATEGORY = "custom/content_top_category.html"
 MARKUP = ['md', 'ipynb']
 
 PLUGIN_PATHS = ['./plugins', './myplugins']
+from pelican_jupyter import markup as nb_markup
 PLUGINS = [
-    'pelican-ipynb.markup',
+    nb_markup,
     'render_math',
     'tag_cloud',
     'related_posts',
@@ -79,6 +80,7 @@ PLUGINS = [
     'excludes_dirnames',
     'skiptags',
 ]
+IGNORE_FILES = [".ipynb_checkpoints"]
 
 RELATED_POSTS_MAX = 3
 

--- a/publishconf.py
+++ b/publishconf.py
@@ -18,8 +18,9 @@ from pelicanconf import *
 # DELETE_OUTPUT_DIRECTORY = True
 
 # plugins which are applied only on publish
+from pelican.plugins import sitemap
 PLUGINS += [
-    'sitemap',
+    sitemap,
 ]
 
 # Add robots.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ beautifulsoup4
 requests
 libsass
 pelican-jupyter
+pelican-sitemap
+pelican-render-math
+pelican-tag-cloud
+pelican-related-posts

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pelican
 Markdown
-nbconvert==5.6.1
+nbconvert
 IPython
 beautifulsoup4
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ IPython
 beautifulsoup4
 requests
 libsass
+pelican-jupyter


### PR DESCRIPTION
This PR also includes update of nbconvert, to which Pelican & plugins are now compatible.