### PR TITLE
Enable `nojekyll` plugin.

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -66,11 +66,13 @@ PLUGIN_PATHS = ['./plugins', './myplugins']
 from pelican_jupyter import markup as nb_markup
 from pelican.plugins import render_math, tag_cloud, related_posts
 from pelican.plugins import simple_footnotes
+from minchin.pelican.plugins import nojekyll
 PLUGINS = [
     nb_markup,
     render_math,
     tag_cloud,
     related_posts,
+    nojekyll,
     'autosummary', 'summary', # this order is important!
     'category_names',
     'shortcodes',

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pelican-render-math
 pelican-tag-cloud
 pelican-related-posts
 pelican-simple-footnotes
+minchin.pelican.plugins.nojekyll


### PR DESCRIPTION
This PR prevents mis-executes of Jekyll on GitHub actions, and also makes the update-appearance faster (according to the plugin document).