### PR TITLE
[Urgent] requirements.txt: Revert nbconvert version to 5.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pelican
 Markdown
-nbconvert
+nbconvert==5.6.1
 IPython
 beautifulsoup4
 requests


### PR DESCRIPTION
Due to my own mistake, all of the jupyter-notebook articles are gone now. This PR corrects it by downgrading `nbconvert` to the compatible version.
Please merge it as soon as possible.