### PR TITLE
Modified CSS for code block padding 

### DIFF
--- a/theme/voidy-bootstrap/static/css/voidybootstrap-custom.css
+++ b/theme/voidy-bootstrap/static/css/voidybootstrap-custom.css
@@ -326,6 +326,10 @@ div.input_area {
     background: #364549!important;
 }
 
+div.input_area > div.highlight {
+    margin: 0px!important;
+}
+
 div.output_subarea {
     max-width: 100%!important;
 }
@@ -335,7 +339,8 @@ div.output_subarea {
   color: #dddddd;
   border-left: none;
   overflow-x: auto;
-  padding-left: 0px;
+	border-radius: 2px;
+  padding: 6px;
   word-break: normal;
   word-wrap: normal;
   white-space: pre;


### PR DESCRIPTION
I modified the css for code blocks. The code block paddings are different between jupyter notebook input block and the raw markdown code block with the present css. So, I deleted the margin depending on jupyter notebook, and added the padding of code blocks. Both code blocks got similar looking.

Before:
![image](https://user-images.githubusercontent.com/41336057/117089021-38cfc080-ad8f-11eb-9978-8ddd1a890ffc.png)

After : 
![image](https://user-images.githubusercontent.com/41336057/117089001-25245a00-ad8f-11eb-99ca-c95712b4fc15.png)
