### PR TITLE
Correct delete_preview.yml, for the issue #228.

### DIFF
--- a/.github/workflows/delete_preview.yml
+++ b/.github/workflows/delete_preview.yml
@@ -45,7 +45,10 @@ jobs:
 
     - name: Delete Preview in the output directory
       run: |
-        rm -rf ./output/previews/$GITHUB_REF
+        rm -rf ./output/previews/$REF
+      env:
+        REF: refs/heads/${{ github.event.ref }}
+      if: github.event.ref_type == 'branch'
 
     - name: Deploy on Site
       run: |


### PR DESCRIPTION
This PR corrects the long-standing bug, #228, enabling to delete previews automatically, when the corresponding PR brunches are deleted.