### PR TITLE
workflows/delete_preview.yml: Correct commit message.

### DIFF
--- a/.github/workflows/delete_preview.yml
+++ b/.github/workflows/delete_preview.yml
@@ -57,6 +57,6 @@ jobs:
         git config --add url.github:.pushInsteadOf https://github.com/
         git config --add url.github:.pushInsteadOf git@github.com:
         git add .
-        git commit -m '$REF branch deleted.' && git push || true
+        git commit -m "$REF branch deleted." && git push || true
       env:
         REF: ${{ github.event.ref }}


### PR DESCRIPTION
Include the name of the deleted branch in the commit message correctly, which was mistakenly displayed as '$REF'.