### PR TITLE
Temporary-aid for jinja2 error in builds.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,4 @@ pelican-simple-footnotes
 pelican-neighbors
 minchin.pelican.plugins.nojekyll
 ipython_genutils
-pelican-jinja2content
 jinja2==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pelican-neighbors
 minchin.pelican.plugins.nojekyll
 ipython_genutils
 pelican-jinja2content
+jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ pelican-neighbors
 minchin.pelican.plugins.nojekyll
 ipython_genutils
 pelican-jinja2content
-jinja2
+jinja2==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pelican-simple-footnotes
 pelican-neighbors
 minchin.pelican.plugins.nojekyll
 ipython_genutils
+pelican-jinja2content


### PR DESCRIPTION
Fix Jinja2==3.03, which deletes the error.
THIS SHOULD NOT BE PERMANENT.
Maybe Pelican updates will correct the error, or maybe we should carry-out some fundamental fix.
The cause of the error is simple. As in https://jinja.palletsprojects.com/en/3.0.x/api/, `contextfilter()` has been deleted from Jinja2 (>=3.1.0) and we must use `pass_context()`.