### PR TITLE
tag_cloud: Change sorting, random -> size.

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -96,6 +96,7 @@ PLUGINS = [
 IGNORE_FILES = [".ipynb_checkpoints"]
 
 RELATED_POSTS_MAX = 3
+TAG_CLOUD_SORTING = "size"
 
 SHORTCODES = {
     'youtube': '''\


### PR DESCRIPTION
Up to now, the tag-list in the sidebar is ordered randomly every time. This PR deforms it such that the tags are sorted by the number of articles, descendingly.