### PR TITLE
Update Python: 3.11 -> 3.13

### DIFF
--- a/.github/workflows/delete_preview.yml
+++ b/.github/workflows/delete_preview.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11' # Semantic version range syntax or exact version of a Python version
+        python-version: '3.13' # Semantic version range syntax or exact version of a Python version
         architecture: 'x64' # Optional - x64 or x86, defaults to x64
 
     - name: Checkout master branch

--- a/.github/workflows/deploy_on_site.yml
+++ b/.github/workflows/deploy_on_site.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11' # Semantic version range syntax or exact version of a Python version
+        python-version: '3.13' # Semantic version range syntax or exact version of a Python version
         architecture: 'x64' # Optional - x64 or x86, defaults to x64
 
     - name: pip update

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11' # Semantic version range syntax or exact version of a Python version
+        python-version: '3.13' # Semantic version range syntax or exact version of a Python version
         architecture: 'x64' # Optional - x64 or x86, defaults to x64
 
     - name: pip update
@@ -61,7 +61,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Semantic version range syntax or exact version of a Python version
+        python-version: '3.13' # Semantic version range syntax or exact version of a Python version
         architecture: 'x64' # Optional - x64 or x86, defaults to x64
 
     - name: Checkout master branch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 pelican
 Markdown
 nbconvert < 6


### PR DESCRIPTION
Now Pelican supports Python 3.13, with setuptools. 